### PR TITLE
Warning fixes, and general cleanup

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -13,4 +13,4 @@ unit_tests: $(OBJS)
 	$(CXX) $(CXX_FLAGS) -c -o $@ $<
 
 clean:
-	rm unit_tests *.o *.gcda *.gcno *.gcov
+	-rm unit_tests *.o *.gcda *.gcno *.gcov

--- a/include/quaternion.h
+++ b/include/quaternion.h
@@ -1,7 +1,8 @@
 /**
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Frank Astier
+ * Copyright (c) 2015 Frank Astier.
+ * Portions copyright (c) 2019 D3 Engineering, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +38,6 @@
 #include <complex>
 #include <iterator>
 #include <assert.h>
-#include <boost/mpl/bool.hpp>
 
 #include "quaternion_utils.h"
 
@@ -1251,14 +1251,14 @@ inline Quaternion<T> pow(const Quaternion<T>& x, int expt) {
     return pow4(x);
 
   Quaternion<T> x4 = pow4(x), y = x4;
-  for (size_t i = 1; i < expt / 4; ++i)
+  for (int i = 1; i < expt / 4; ++i)
     y *= x4;
   if (expt % 4 == 3)
     y *= pow3(x);
   if (expt % 4 == 2)
     y *= pow2(x);
   if (expt % 4 == 1)
-    y *= x; std::pow(3,4);
+    y *= x;
   return y;
 }
 

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -30,6 +30,7 @@
 #include <chrono> // definitely needed on some platforms, but maybe not with clang
 #include <random>
 #include <iomanip>
+#include <functional>
 
 #include <boost/math/quaternion.hpp>
 #include <boost/rational.hpp>
@@ -209,7 +210,7 @@ operator*(const array<array<T,n>,n>& a, const array<array<T,n>,n>& b) {
  */
 std::default_random_engine generator;
 std::uniform_real_distribution<float> distribution(0.0,1.0);
-auto rng = bind(distribution, generator);
+auto rng = std::bind(distribution, generator);
 
 /**
  * A function to generate random quaternions.
@@ -1538,7 +1539,8 @@ void test_multiplication_speed() {
   cout << "Testing multiplication speed" << endl;
   size_t N = 100000;
 
-  Qf q1 = random_quaternion<float>(rng), q2 = random_quaternion<float>(rng);
+  Qf q1 = random_quaternion<float>(rng);
+  Qf q2 = random_quaternion<float>(rng);
 
   {
     float certificate = 0.0;
@@ -1647,7 +1649,8 @@ void test_axby_speed() {
   cout << "Testing axby speed" << endl;
   size_t N = 100000;
 
-  Qf q1 = random_quaternion<float>(rng), q2 = random_quaternion<float>(rng);
+  Qf q1 = random_quaternion<float>(rng);
+  Qf q2 = random_quaternion<float>(rng);
 
   { // With Boost
     qf a(q1.a(),q1.b(),q1.c(),q1.d()), b(q2.a(),q2.b(),q2.c(),q2.d());

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -1769,6 +1769,7 @@ int main(int argc, char** argv) {
   test_pow_speed();
   test_axby_speed();
   test_tan_speed();
+  cout << "All tests completed OK" << endl;
 
   return 0;
 }


### PR DESCRIPTION
Thank you for this library!  This PR builds on #2, commit 24819c5.  I only wrote a79a8d7.

- Change size_t to int to fix signed/unsigned comparison warnings
- Removed `std::pow` call whose value was never used
- Added a message at the end of the unit tests to let the first-time reader know that the tests completed successfully
- Makefile.mk, `clean` target: ignore errors in `rm`.  This way nonexistent files don't trigger an error message.
- include/quaternions.h: Don't include `boost/mpl/bool.hpp`, since the README says Boost is only used for unit testing.  All unit tests pass on my machine even without this header.
- The "Portions copyright (c) 2019 D3 Engineering, LLC" message is a condition from my employer (I'm using my work computer).  This is not a request for any change to the licensing --- no worries!

Thank you for considering this PR!