### PR TITLE
quaternion.h: add missing #include <cstdint>

### DIFF
--- a/include/quaternion.h
+++ b/include/quaternion.h
@@ -29,8 +29,8 @@
 #ifndef QUATERNIONS_QUATERNION_H
 #define QUATERNIONS_QUATERNION_H
 
-#include <math.h> // for atan2, which handles signs for us properly
-
+#include <cmath> // for atan2, which handles signs for us properly
+#include <cstdint>
 #include <limits>
 #include <type_traits>
 #include <array>


### PR DESCRIPTION
Fixes
```
quaternion.h:739:19: error: ‘uint64_t’ has not been declared
```
when compiling with aarch64-linux-gnu-g++-14.